### PR TITLE
Add rsync to the list of installed tools in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install some tools and compilers + clean up
 RUN apt-get update && \
-    apt-get install -y git wget gcc-8 g++-8 cmake gdb gdbserver bzip2 && \
+    apt-get install -y rsync git wget gcc-8 g++-8 cmake gdb gdbserver bzip2 && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes "/bin/sh: 1: rsync: not found" error #9 