### PR TITLE
Dockerfile: manualy set LIMITS_H_TEST=true to fix limits.h include order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN ../${GCC_VERSION}/configure \
         --enable-languages=c,c++,fortran \
         --with-arch=armv6 --with-fpu=vfp --with-float=hard \
         --disable-multilib
-RUN make -j$(nproc) all-gcc
+RUN make -j$(nproc) 'LIMITS_H_TEST=true' all-gcc
 RUN make install-gcc
 ENV PATH=/opt/cross-pi-gcc/bin:${PATH}
 


### PR DESCRIPTION
This patch is taken from chromium.org

https://src.chromium.org/viewvc/native_client/trunk/src/native_client/toolchain_build/toolchain_build.py?r1=10387&r2=10386&pathrev=10387

Original patch description:

gcc/Makefile's install rules ordinarily look at the
installed include directory for a limits.h to decide
whether the lib/gcc/.../include-fixed/limits.h header
should be made to expect a libc-supplied limits.h or not.
Since we're doing this build in a clean environment without
any libc installed, we need to force its hand here.